### PR TITLE
[CMLG-007] fix the first column

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -8,47 +8,36 @@
   width: auto;
 }
 
+// all header cells
+th:nth-child(n) {
+  background-color:skyblue;
+  font-weight: bold;
+}
+
+// first cell in the header
 th:nth-child(1) {
-  position: sticky;
   left: 0;
-  width: 23%;
-  z-index: 3;
-  background-color:white;
+  z-index: 200;
+  background-color:skyblue;
+  font-weight: bold;
 }
 
+//child on first column
 td:nth-child(2) {
+  position: -webkit-sticky; /* Safari */
   position: sticky;
   left: 0;
-  width: 23%;
   z-index: 1;
-  background-color:white;
 }
 
-th:nth-child(2) {
-  position: sticky;
-  left: 23%;
-  width: 30%;
-  z-index: 3;
-  background-color:white;
+// background colour for even rows in first column
+tr:nth-child(even) > td:nth-child(2) {
+  background: #cceeff;
 }
 
-td:nth-child(4) {
-  position: sticky;
-  left: 23%;
-  width: 30%;
-  z-index: 1;
-  background-color:white;
-}
-
-th:nth-child(3), th:nth-child(4), th:nth-child(5) {
-  position: sticky;
-  top: 0;
+// background colour for odd rows in first column
+tr:nth-child(odd) > td:nth-child(2) {
   background: white;
-  z-index: 2;
-}
-
-th:first-child, th:nth-child(2) {
-  z-index: 3;
 }
 
 tr:nth-child(2n) {


### PR DESCRIPTION
**Issue:**

The background colour of each row doesn't go all the way to the fixed columns.
There is a gap between the first and second column.
title row looks exactly the same as the body of the table.

**Solution:**

Fix only the first column and leave the second column unfixed.
Change the background colour of the first column, so the background colour across each row is consistent.
Give the title a different background colour and bold the title text.

_Notes:_
To fix the position of the second column, we need to know the width of first column during runtime. This is difficult to achieve now but it is something that user wants. Therefore, we will still need to implement it in the future.

**Risk: ** /

**Reviewed by:**
Annie, Eileen, Dave, Yujia, Kevin