### PR TITLE
[CMLG-001] Enabled responsive horizontal scroll of the table grid

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -3,9 +3,9 @@
 }
 
 .MuiPaper-root MUIDataTable-paper-2 undefined MuiPaper-elevation4 MuiPaper-rounded {
-  overflow-x: auto;
-  // height: auto;
-  // width: auto;
+  overflow: auto;
+  height: auto;
+  width: auto;
 }
 
 // all header cells

--- a/src/App.scss
+++ b/src/App.scss
@@ -51,5 +51,6 @@ tr:nth-child(2n) {
 /* Ensures only the table grid is scrolling */
 .MUIDataTable-responsiveScrollFullHeight-7 {
   overflow-x: auto !important;
+  height: 92vh !important;
 }
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -3,9 +3,9 @@
 }
 
 .MuiPaper-root MUIDataTable-paper-2 undefined MuiPaper-elevation4 MuiPaper-rounded {
-  overflow: auto;
-  height: auto;
-  width: auto;
+  overflow-x: auto;
+  // height: auto;
+  // width: auto;
 }
 
 // all header cells
@@ -46,5 +46,10 @@ tr:nth-child(2n) {
 
 .MuiPaper-elevation4 {
   box-shadow: none !important;
+}
+
+/* Ensures only the table grid is scrolling */
+.MUIDataTable-responsiveScrollFullHeight-7 {
+  overflow-x: auto !important;
 }
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -51,6 +51,6 @@ tr:nth-child(2n) {
 /* Ensures only the table grid is scrolling */
 .MUIDataTable-responsiveScrollFullHeight-7 {
   overflow-x: auto !important;
-  height: 92vh !important;
+  height: 89vh !important;
 }
 


### PR DESCRIPTION
Issue:
When scrolling horizontally the entire webpage moves, when we only want the table to in a smaller screen.

Solution:
Changed the css for the container for the table tag to overflow-x: auto !important.
Fixed the problem with z-index of the table headers.

Risk:
The !important flag may cause issues, but not entirely sure.

Reviewed by: Yujia, Kevin, Dave, Emily, Eileen