### PR TITLE
[CMLG-011] Sort table when the user clicks the column 

### DIFF
--- a/src/components/SearchPage.js
+++ b/src/components/SearchPage.js
@@ -15,8 +15,9 @@ class SearchPage extends React.Component {
     }
 
     initLanguages() {
-        const languages = [ "Chinese", "English", "Italian", "Arabic", "Serbian", "Croatian", "Russian", "German", "Hebrew", "French",
-                            "Hungarian", "Slovak", "Spanish", "Portugues", "Turkce", "Greek", "Romanian" ]
+        const languages = [ "Chinese", "English", "Italian", "Arabic", "Serbian", "Croatian", "Russian", "German",
+                            "Hebrew", "French", "Hungarian", "Slovak", "Spanish", "Português", "Türkçe", "Greek",
+                            "Romanian" ]
         let allLanguages = []
         languages.forEach( ( language, index ) => {
             if ( index < 5 ) {
@@ -55,7 +56,7 @@ class SearchPage extends React.Component {
             <div className = "SearchPage">
                 <SearchBar data = { { changeWord: this.handleChangeWord.bind( this ) } }> </SearchBar>
                 <SelectCol getsSelectedLanguage = { this.handleSelectCol } allLanguages = { this.state.selectedColumns }/>
-                <Table />
+                <Table columns = { this.state.selectedColumns } />
             </div>
         );
     }

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -109,7 +109,7 @@ class Table extends React.Component {
                         <td>{ romanian }</td>
                     </tr>
                 )
-            })
+            } )
         } else {
             return (
                 <tr>
@@ -135,7 +135,7 @@ class Table extends React.Component {
         fetch( 'https://cmlgbackend.wdcc.co.nz/translations' )
             .then( results => {
                 return results.json();
-            })
+            } )
             .then( data => {
                 let sortedListOfWords = [];
                 let translationsForOneWord = [];
@@ -165,10 +165,10 @@ class Table extends React.Component {
                     }
                 }
 
-                this.setState({
+                this.setState( {
                     translationData: sortedListOfWords
-                });
-            })
+                } );
+            } )
     }
 
     sortColumn( event ) {
@@ -191,7 +191,7 @@ class Table extends React.Component {
 
         const order = newColumnConfig[ clickedColumnIndex ].sortOrder;
         let sortedTranslationData = this.state.translationData.slice();
-        sortedTranslationData.sort(( row1, row2 ) => {
+        sortedTranslationData.sort( ( row1, row2 ) => {
 
             let word1 = row1[ sortElementIndex ];
             let word2 = row2[ sortElementIndex ];
@@ -211,12 +211,12 @@ class Table extends React.Component {
                 }
             }
 
-        });
+        } );
 
-        this.setState({
+        this.setState( {
             translationData: sortedTranslationData,
             columnConfig: newColumnConfig
-        })
+        } )
     }
 
 

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -1,11 +1,83 @@
 import React from "react";
-
+import './css/Table.css'
 
 class Table extends React.Component {
     constructor( props ) {
         super( props )
         this.state = {
-            translationData: []
+            translationData: [],
+            sortInIncreasingOrder: true,
+            columnConfig: [
+                {
+                    name: "zh_cn",
+                    sortOrder: "undefined"
+                },
+                {
+                    name: "English",
+                    sortOrder: "undefined"
+                },
+                {
+                    name: "it_italiano",
+                    sortOrder: "undefined"
+                },
+                {
+                    name: "arabic",
+                    sortOrder: "undefined"
+                },
+                {
+                    name: "serbian",
+                    sortOrder: "undefined",
+
+                },
+                {
+                    name: "croatian",
+                    sortOrder: "undefined"
+                },
+                {
+                    name: "russian",
+                    sortOrder: "undefined"
+                },
+                {
+                    name: "de_german",
+                    sortOrder: "undefined"
+                },
+                {
+                    name: "hebrew",
+                    sortOrder: "undefined"
+                },
+                {
+                    name: "fr_french",
+                    sortOrder: "undefined"
+                },
+                {
+                    name: "hu_hungarian",
+                    sortOrder: "undefined"
+                },
+                {
+                    name: "slovak",
+                    sortOrder: "undefined"
+                },
+                {
+                    name: "es_spanish",
+                    sortOrder: "undefined"
+                },
+                {
+                    name: "portugues",
+                    sortOrder: "undefined"
+                },
+                {
+                    name: "turkce",
+                    sortOrder: "undefined"
+                },
+                {
+                    name: "gr_greek",
+                    sortOrder: "undefined"
+                },
+                {
+                    name: "romanian",
+                    sortOrder: "undefined"
+                }
+            ]
         };
     }
 
@@ -48,6 +120,18 @@ class Table extends React.Component {
         }
     }
 
+    renderTableHeader() {
+        return (
+            this.state.columnConfig.map( ( column, index ) => {
+                return (
+                    <th key={ index } scope={ "col" } className={ column.sortOrder }
+                        onClick={ ( event ) => this.sortColumn( event ) }>{ column.name }
+                    </th>
+                );
+            } )
+        );
+    }
+
     componentDidMount() {
         fetch( 'https://cmlgbackend.wdcc.co.nz/translations' )
             .then( results => {
@@ -88,28 +172,61 @@ class Table extends React.Component {
             })
     }
 
+    sortColumn( event ) {
+
+        // headers in the table are in the format: [ chinese + pinyin, english ... ]
+        // translationData contains array in the format: [ chinese, pinyin, english ... ]
+        const clickedColumnIndex = event.target.cellIndex;
+        const sortElementIndex = clickedColumnIndex + 1;
+
+        let newColumnConfig = this.state.columnConfig.slice();
+
+        newColumnConfig.map( ( column, index ) => {
+            if ( index === clickedColumnIndex ) {
+                return column.sortOrder === "ascending" ? column.sortOrder = "descending" :
+                       column.sortOrder = "ascending";
+            } else {
+                return column.sortOrder = "undefined"
+            }
+        } )
+
+        const order = newColumnConfig[ clickedColumnIndex ].sortOrder;
+        let sortedTranslationData = this.state.translationData.slice();
+        sortedTranslationData.sort(( row1, row2 ) => {
+
+            let word1 = row1[ sortElementIndex ];
+            let word2 = row2[ sortElementIndex ];
+
+            if ( !word1 ) {
+                return 1;
+            } else if ( !word2 ) {
+                return -1;
+            } else {
+
+                const collator = new Intl.Collator();
+
+                if ( order === "ascending" ) {
+                    return collator.compare( word1, word2 );
+                } else {
+                    return collator.compare( word2, word1 );
+                }
+            }
+
+        });
+
+        this.setState({
+            translationData: sortedTranslationData,
+            columnConfig: newColumnConfig
+        })
+    }
+
+
     render() {
         return (
             <table className="table table-striped">
                 <thead>
                     <tr>
-                        <th scope="col">zh_cn</th>
-                        <th scope="col">English</th>
-                        <th scope="col">it_italiano</th>
-                        <th scope="col">arabic</th>
-                        <th scope="col">serbian</th>
-                        <th scope="col">croatian</th>
-                        <th scope="col">russian</th>
-                        <th scope="col">de_german</th>
-                        <th scope="col">hebrew</th>
-                        <th scope="col">fr_french</th>
-                        <th scope="col">hu_hungarian</th>
-                        <th scope="col">slovak</th>
-                        <th scope="col">es_spanish</th>
-                        <th scope="col">portugues</th>
-                        <th scope="col">turkce</th>
-                        <th scope="col">gr_greek</th>
-                        <th scope="col">romanian</th>
+                        { this.renderTableHeader() }
                     </tr>
                 </thead>
 

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -62,7 +62,7 @@ class Table extends React.Component {
                     sortOrder: "undefined"
                 },
                 {
-                    name: "portugues",
+                    name: "portuguese",
                     sortOrder: "undefined"
                 },
                 {

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -6,7 +6,6 @@ class Table extends React.Component {
         super( props )
         this.state = {
             translationData: [],
-            sortInIncreasingOrder: true,
             columnConfig: [
                 {
                     name: "zh_cn",
@@ -120,7 +119,7 @@ class Table extends React.Component {
         }
     }
 
-    renderTableHeader() {
+    renderTableHeaders() {
         return (
             this.state.columnConfig.map( ( column, index ) => {
                 return (
@@ -226,7 +225,7 @@ class Table extends React.Component {
             <table className="table table-striped">
                 <thead>
                     <tr>
-                        { this.renderTableHeader() }
+                        { this.renderTableHeaders() }
                     </tr>
                 </thead>
 

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -6,77 +6,7 @@ class Table extends React.Component {
         super( props )
         this.state = {
             translationData: [],
-            columnConfig: [
-                {
-                    name: "zh_cn",
-                    sortOrder: "undefined"
-                },
-                {
-                    name: "English",
-                    sortOrder: "undefined"
-                },
-                {
-                    name: "it_italiano",
-                    sortOrder: "undefined"
-                },
-                {
-                    name: "arabic",
-                    sortOrder: "undefined"
-                },
-                {
-                    name: "serbian",
-                    sortOrder: "undefined",
-
-                },
-                {
-                    name: "croatian",
-                    sortOrder: "undefined"
-                },
-                {
-                    name: "russian",
-                    sortOrder: "undefined"
-                },
-                {
-                    name: "de_german",
-                    sortOrder: "undefined"
-                },
-                {
-                    name: "hebrew",
-                    sortOrder: "undefined"
-                },
-                {
-                    name: "fr_french",
-                    sortOrder: "undefined"
-                },
-                {
-                    name: "hu_hungarian",
-                    sortOrder: "undefined"
-                },
-                {
-                    name: "slovak",
-                    sortOrder: "undefined"
-                },
-                {
-                    name: "es_spanish",
-                    sortOrder: "undefined"
-                },
-                {
-                    name: "portuguese",
-                    sortOrder: "undefined"
-                },
-                {
-                    name: "turkce",
-                    sortOrder: "undefined"
-                },
-                {
-                    name: "gr_greek",
-                    sortOrder: "undefined"
-                },
-                {
-                    name: "romanian",
-                    sortOrder: "undefined"
-                }
-            ]
+            columnSortStatus: new Array( 17 ).fill( "undefined" )
         };
     }
 
@@ -121,10 +51,11 @@ class Table extends React.Component {
 
     renderTableHeaders() {
         return (
-            this.state.columnConfig.map( ( column, index ) => {
+            this.state.columnSortStatus.map( ( sortStatus, colIndex ) => {
                 return (
-                    <th key={ index } scope={ "col" } className={ column.sortOrder }
-                        onClick={ ( event ) => this.sortColumn( event ) }>{ column.name }
+                    <th key={ colIndex } scope={ "col" } className={ sortStatus }
+                        onClick={ ( event ) => this.sortColumn( event ) }>
+                        { this.props.columns[ colIndex ].id }
                     </th>
                 );
             } )
@@ -178,18 +109,18 @@ class Table extends React.Component {
         const clickedColumnIndex = event.target.cellIndex;
         const sortElementIndex = clickedColumnIndex + 1;
 
-        let newColumnConfig = this.state.columnConfig.slice();
+        let newColumnSortStatus = this.state.columnSortStatus.slice();
 
-        newColumnConfig.map( ( column, index ) => {
-            if ( index === clickedColumnIndex ) {
-                return column.sortOrder === "ascending" ? column.sortOrder = "descending" :
-                       column.sortOrder = "ascending";
+        newColumnSortStatus.map( ( sortDirection, colIndex ) => {
+            if ( colIndex === clickedColumnIndex ) {
+                return sortDirection === "ascending" ? newColumnSortStatus[ colIndex ] = "descending" :
+                       newColumnSortStatus[ colIndex ] = "ascending";
             } else {
-                return column.sortOrder = "undefined"
+                return newColumnSortStatus[ colIndex ] = "undefined";
             }
         } )
 
-        const order = newColumnConfig[ clickedColumnIndex ].sortOrder;
+        const order = newColumnSortStatus[ clickedColumnIndex ];
         let sortedTranslationData = this.state.translationData.slice();
         sortedTranslationData.sort( ( row1, row2 ) => {
 
@@ -215,7 +146,7 @@ class Table extends React.Component {
 
         this.setState( {
             translationData: sortedTranslationData,
-            columnConfig: newColumnConfig
+            columnSortStatus: newColumnSortStatus
         } )
     }
 

--- a/src/components/css/Table.css
+++ b/src/components/css/Table.css
@@ -1,0 +1,13 @@
+thead th.ascending::after {
+    content: ' \2191';
+}
+
+thead th.descending::after {
+    content: ' \2193';
+}
+
+thead th:hover {
+    cursor: pointer;
+}
+
+


### PR DESCRIPTION
**Issue:**

SearchPage is passing names of headers to the Table component, Table component no longer needs to store this information.

The header name "Portugues" and "Turkce" are not the same as the one in the excel sheet that the user provides.

**Solution:**

Table component is now displaying the headers of the table using the props passed by the SearchPage component.

Changing Portugues to Português and Turkce to Türkçe in order to match the excel sheet.

**Risk:**
/

**Reviewed by:**
Annie, Eileen, Yujia, Kevin, Dave