### PR TITLE
[CMLG-011] fix the displaying data issue with new API

### DIFF
--- a/src/components/SearchPage.js
+++ b/src/components/SearchPage.js
@@ -56,7 +56,9 @@ class SearchPage extends React.Component {
             <div className = "SearchPage">
                 <SearchBar data = { { changeWord: this.handleChangeWord.bind( this ) } }> </SearchBar>
                 <SelectCol getsSelectedLanguage = { this.handleSelectCol } allLanguages = { this.state.selectedColumns }/>
-                <Table columns = { this.state.selectedColumns } />
+                <Table columns = { this.state.selectedColumns }
+                       words = { this.state.word }
+                />
             </div>
         );
     }

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -82,18 +82,18 @@ class Table extends React.Component {
 
     getData() {
         let sequenceTime = new Date();
+        let url = 'https://cmlgbackend.wdcc.co.nz/api/translations?sequence=' + sequenceTime.getTime();
 
-        const url = 'https://cmlgbackend.wdcc.co.nz/api/translations?sequence=' + sequenceTime.getTime() + '&word='
-            + this.props.words;
-        
+        if ( !this.state.loading ) {
+            url = url + '&word=' + this.props.words;
+        }
+
         fetch( url )
             .then( results => {
                 return results.json();
             } )
             .then( responseData => {
-
                 const data = responseData.data;
-
                 let sortedListOfWords = [];
                 let translationsForOneWord = [];
                 let dataIndex;

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -82,11 +82,8 @@ class Table extends React.Component {
 
     getData() {
         let sequenceTime = new Date();
-        let url = 'https://cmlgbackend.wdcc.co.nz/api/translations?sequence=' + sequenceTime.getTime();
-
-        if ( !this.state.loading ) {
-            url = url + '&word=' + this.props.words;
-        }
+        let url = 'https://cmlgbackend.wdcc.co.nz/api/translations?sequence=' + sequenceTime.getTime() +
+                  '&word=' + this.props.words;
 
         fetch( url )
             .then( results => {


### PR DESCRIPTION
Issue:

The table doesn't have a word property so the search word is not passed to Table.
When the website first loads, the word is null but we don't want to pass null as the search word to the API. Instead, we want the API to returns the first ten rows.

Solution:

Pass a property words to the table component.
Check if the website is loading, if it is, call /translations?sequence=xxx end point instead of /translations?sequence=xxx?word=null

Risk:
/

Reviewed by:
Annie, Dave, Eileen, Yujia, Kevin