### PR TITLE
[CMLG-011] Only display the most recent search result

### DIFF
--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -7,7 +7,8 @@ class Table extends React.Component {
         this.state = {
             translationData: [],
             columnSortStatus: new Array( 17 ).fill( "undefined" ),
-            loading: true // True when the data is loading at initialisation. False when there are no search results.
+            loading: true, // True when the data is loading at initialisation. False when there are no search results.
+            sequence: -1
         };
     }
 
@@ -91,6 +92,12 @@ class Table extends React.Component {
             } )
             .then( responseData => {
                 const data = responseData.data;
+                const sequence = responseData.sequence;
+
+                if ( sequence <= this.state.sequence ) {
+                    return;
+                }
+
                 let sortedListOfWords = [];
                 let translationsForOneWord = [];
                 let dataIndex;
@@ -119,7 +126,8 @@ class Table extends React.Component {
                 }
                 this.setState( {
                     translationData: sortedListOfWords,
-                    loading: false
+                    loading: false,
+                    sequence: sequence
                 } );
             } )
     }


### PR DESCRIPTION
**Issue:**

Frontend gets responses in random order, the frontend needs to decide which response to process and put on the table. For example, when the user searches for "u" and "p", the response for "up" comes first. When the response for "u" arrives, the frontend needs to realise this response is no longer needed and delete it.

**Solution:**

Because the response contains a sequence number, the Table component contains the sequence of the currently displayed response. When receiving the next response, the Table component looks at the sequence number, and only displays the data if its sequence is larger than the current one.

**Risk:**
/

**Reviewed by:**
Annie, Eileen, Dave, Kevin, Yujia