### PR TITLE
[CMLG-011] Put the scroll bar on table only

### DIFF
--- a/src/components/SearchPage.js
+++ b/src/components/SearchPage.js
@@ -53,12 +53,12 @@ class SearchPage extends React.Component {
 
     render() {
         return (
-            <div className = "SearchPage" style={{ display: "grid", height: "100vh" }}>
+            <div className = "SearchPage" style={ { display: "grid", height: "100vh" } }>
                 <div>
                     <SearchBar data = { { changeWord: this.handleChangeWord.bind( this ) } }> </SearchBar>
                     <SelectCol getsSelectedLanguage = { this.handleSelectCol } allLanguages = { this.state.selectedColumns }/>
                 </div>
-                <div style={{ overflow: "scroll", height: "100%" }}>
+                <div style={ { overflow: "scroll", height: "100%" } }>
                     <Table columns = { this.state.selectedColumns }
                            words = { this.state.word }
                     />

--- a/src/components/SearchPage.js
+++ b/src/components/SearchPage.js
@@ -3,6 +3,8 @@ import SelectCol from "./SelectCol";
 import SearchBar from './SearchBar'
 import Table from "./Table";
 
+import "./css/SearchPage.css"
+
 class SearchPage extends React.Component {
 
     constructor( props ) {
@@ -53,12 +55,13 @@ class SearchPage extends React.Component {
 
     render() {
         return (
-            <div className = "SearchPage" style={ { display: "grid", height: "100vh" } }>
+            <div className = "search-page">
                 <div>
                     <SearchBar data = { { changeWord: this.handleChangeWord.bind( this ) } }> </SearchBar>
-                    <SelectCol getsSelectedLanguage = { this.handleSelectCol } allLanguages = { this.state.selectedColumns }/>
+                    <SelectCol getsSelectedLanguage = { this.handleSelectCol }
+                               allLanguages = { this.state.selectedColumns }/>
                 </div>
-                <div style={ { overflow: "scroll", height: "100%" } }>
+                <div className = "table-div">
                     <Table columns = { this.state.selectedColumns }
                            words = { this.state.word }
                     />

--- a/src/components/SearchPage.js
+++ b/src/components/SearchPage.js
@@ -53,12 +53,16 @@ class SearchPage extends React.Component {
 
     render() {
         return (
-            <div className = "SearchPage">
-                <SearchBar data = { { changeWord: this.handleChangeWord.bind( this ) } }> </SearchBar>
-                <SelectCol getsSelectedLanguage = { this.handleSelectCol } allLanguages = { this.state.selectedColumns }/>
-                <Table columns = { this.state.selectedColumns }
-                       words = { this.state.word }
-                />
+            <div className = "SearchPage" style={{ display: "grid", height: "100vh" }}>
+                <div>
+                    <SearchBar data = { { changeWord: this.handleChangeWord.bind( this ) } }> </SearchBar>
+                    <SelectCol getsSelectedLanguage = { this.handleSelectCol } allLanguages = { this.state.selectedColumns }/>
+                </div>
+                <div style={{ overflow: "scroll", height: "100%" }}>
+                    <Table columns = { this.state.selectedColumns }
+                           words = { this.state.word }
+                    />
+                </div>
             </div>
         );
     }

--- a/src/components/css/SearchPage.css
+++ b/src/components/css/SearchPage.css
@@ -8,3 +8,4 @@
     overflow: scroll;
     height: 100%;
 }
+

--- a/src/components/css/SearchPage.css
+++ b/src/components/css/SearchPage.css
@@ -1,0 +1,10 @@
+.search-page {
+    display: grid;
+    height: 100vh;
+    grid-template-rows: max-content;
+}
+
+.table-div {
+    overflow: scroll;
+    height: 100%;
+}


### PR DESCRIPTION
**Issue:**

Scrolling bar is put on the browser, when the user scrolls the page to the right, all components including the search bar and select component are scrolled.

**Solution:**

The table cannot have "overflow" CSS on it. Therefore, change the display of searchPage to be "grid", the search page component contains two rows. Searchbar and select components are in the first row. The table is in the second row. Change the overflow of the div around the table to be "scroll".

**Risk:**

When scrolling the table vertically, the header moves as well.

**Reviewed by:**

Annie, Dave, Eileen, Yujia, Kevin