### PR TITLE
[CMLG-011] Fix responsive issue when sorting columns

### DIFF
--- a/src/components/SearchPage.js
+++ b/src/components/SearchPage.js
@@ -61,6 +61,7 @@ class SearchPage extends React.Component {
                     <SelectCol getsSelectedLanguage = { this.handleSelectCol }
                                allLanguages = { this.state.selectedColumns }/>
                 </div>
+
                 <div className = "table-div">
                     <Table columns = { this.state.selectedColumns }
                            words = { this.state.word }

--- a/src/components/css/Table.css
+++ b/src/components/css/Table.css
@@ -1,3 +1,7 @@
+thead th {
+    white-space: nowrap;
+}
+
 thead th.ascending::after {
     content: ' \2191';
 }


### PR DESCRIPTION
**Issue:**

When sorting columns, there is a small arrow appearing beside the header clicked, indicating the sorting order. If the width of the header is not enough, the arrow goes to the next line.

**Solution:**

Add CSS style "white-space: nowrap" to force the arrow to be on the same line.

**Risk:**

As the width of the header is not enough for the arrow to be on the same line, when the arrow appears, the width of the header will get automatically larger to fit both words and arrow.

**Reviewed by:**
Annie, Eileen, Kevin, Dave, Yujia