### PR TITLE
[CMLG-012] delay onChange event when user types something in the search box

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "lodash.debounce": "^4.0.8"
   }
 }

--- a/src/components/SearchPage.js
+++ b/src/components/SearchPage.js
@@ -2,6 +2,7 @@ import React from 'react';
 import SelectCol from "./SelectCol";
 import SearchBar from './SearchBar'
 import Table from "./Table";
+import debounce from 'lodash.debounce';
 
 import "./css/SearchPage.css"
 
@@ -14,6 +15,9 @@ class SearchPage extends React.Component {
             selectedColumns : this.initLanguages(),
             word: ''
         };
+
+        // only emit changes if this function has not been called in the past 180 ms
+        this.emitChangeDebounced = debounce(this.emitChange, 180);
     }
 
     initLanguages() {
@@ -39,8 +43,12 @@ class SearchPage extends React.Component {
         return allLanguages;
     }
 
-    // change the searching word which is provided by the SearchBar class
     handleChangeWord( searchWord ) {
+        this.emitChangeDebounced( searchWord );
+    }
+
+    // change the searching word which is provided by the SearchBar class
+    emitChange( searchWord ) {
         this.setState( {
             word: searchWord
         } );


### PR DESCRIPTION
**Issue:**
The frontend is sending a request to the backend every time the user types something, which quickly reaches the API rate limit.

**Solution:**
Only changes the state if the user doesn't type for 180 ms.

**Risk:**
need to run npm install again as a new library is downloaded for debouncing. 

**Reviewed by:**
Annie, Dave, Eileen, Kevin, Yujia