### PR TITLE
[CMLG-015] Refactor the code in Table and SearchPage components

### DIFF
--- a/src/components/SearchPage.js
+++ b/src/components/SearchPage.js
@@ -78,7 +78,7 @@ class SearchPage extends React.Component {
 
         let sequenceTime = new Date();
         let url = 'https://cmlgbackend.wdcc.co.nz/api/translations?sequence=' + sequenceTime.getTime() +
-            '&word=' + this.state.word;
+                  '&word=' + this.state.word;
 
         fetch( url )
             .then( results => {

--- a/src/components/SearchPage.js
+++ b/src/components/SearchPage.js
@@ -11,7 +11,6 @@ class SearchPage extends React.Component {
     constructor( props ) {
         super( props );
         this.state = {
-            //@todo place to store value such as search term and select column
             selectedColumns : this.initLanguages(),
             word: '',
             tableData: [],
@@ -76,7 +75,6 @@ class SearchPage extends React.Component {
 
     // retrieve data for table
     retrieveTableData() {
-        console.log("retrieve data called");
 
         let sequenceTime = new Date();
         let url = 'https://cmlgbackend.wdcc.co.nz/api/translations?sequence=' + sequenceTime.getTime() +
@@ -104,7 +102,7 @@ class SearchPage extends React.Component {
 
                     // Check if the translated word is in the correct column (under the correct language). So if the
                     // English translation for the word is not under English, throw an exception.
-                    // + 1 infront of translationsForOneWord.length because the index starts from 0, whereas language_id
+                    // + 1 in front of translationsForOneWord.length because the index starts from 0, whereas language_id
                     // starts from 1.
                     if ( translationsForOneWord.length + 1 === currentData.language_id ) {
                         translationsForOneWord[ translationsForOneWord.length ] = currentData.name;

--- a/src/components/SearchPage.js
+++ b/src/components/SearchPage.js
@@ -68,7 +68,7 @@ class SearchPage extends React.Component {
     }
 
     componentDidUpdate( prevProps, prevState, snapshot ) {
-        if (this.state.word !== prevState.word ) {
+        if ( this.state.word !== prevState.word ) {
             this.retrieveTableData();
         }
     }

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -5,14 +5,26 @@ class Table extends React.Component {
     constructor( props ) {
         super( props )
         this.state = {
-            translationData: [],
-            columnSortStatus: new Array( 17 ).fill( "undefined" ),
-            loading: true, // True when the data is loading at initialisation. False when there are no search results.
-            sequence: -1
+            translationData: this.props.data,
+            columnSortStatus: new Array( 17 ).fill( "undefined" )
         };
     }
 
+    componentDidUpdate( prevProps: Readonly<P>, prevState: Readonly<S>, snapshot: SS ) {
+        console.log("component did update gets called");
+
+        if ( this.props.data !== prevState.translationData ) {
+            console.log("update state is called")
+            this.setState( {
+                translationData: this.props.data
+            } )
+        }
+    }
+
     renderTableData() {
+        console.log("data in table state")
+        console.log(this.state.translationData);
+
         if ( this.state.translationData.length !== 0 ) {
             return this.state.translationData.map( ( translation, index ) => {
 
@@ -53,7 +65,7 @@ class Table extends React.Component {
                     </tr>
                 )
             } )
-        } else if ( this.state.loading ) {
+        } else if ( this.props.isLoading ) {
             return (
                 <tr>
                     <td>{ "Loading" }</td>
@@ -96,67 +108,6 @@ class Table extends React.Component {
                 }
             } )
         );
-    }
-
-    getData() {
-        let sequenceTime = new Date();
-        let url = 'https://cmlgbackend.wdcc.co.nz/api/translations?sequence=' + sequenceTime.getTime() +
-                  '&word=' + this.props.words;
-
-        fetch( url )
-            .then( results => {
-                return results.json();
-            } )
-            .then( responseData => {
-                const data = responseData.data;
-                const sequence = responseData.sequence;
-
-                if ( sequence <= this.state.sequence ) {
-                    return;
-                }
-
-                let sortedListOfWords = [];
-                let translationsForOneWord = [];
-                let dataIndex;
-                let currentData;
-
-                for ( dataIndex = 0; dataIndex < data.length; dataIndex++ ) {
-                    currentData = data[ dataIndex ];
-
-                    // Check if the translated word is in the correct column (under the correct language). So if the
-                    // English translation for the word is not under English, throw an exception.
-                    // + 1 infront of translationsForOneWord.length because the index starts from 0, whereas language_id
-                    // starts from 1.
-                    if ( translationsForOneWord.length + 1 === currentData.language_id ) {
-                        translationsForOneWord[ translationsForOneWord.length ] = currentData.name;
-                    } else {
-                        throw new Error( "The translated word does not match the language." );
-                    }
-
-                    const numberOfLanguages = 18;
-                    // When the word is translated to all languages, add translationsForOneWord into sortedListOfWords.
-                    // Empty translationsForOneWord so a new translationsForOneWord can be made for a new word.
-                    if ( translationsForOneWord.length === numberOfLanguages ) {
-                        sortedListOfWords[ sortedListOfWords.length ] = translationsForOneWord;
-                        translationsForOneWord = [];
-                    }
-                }
-                this.setState( {
-                    translationData: sortedListOfWords,
-                    loading: false,
-                    sequence: sequence
-                } );
-            } )
-    }
-
-    componentDidMount() {
-        this.getData();
-    }
-
-    componentDidUpdate( prevProps, prevState, snapshot ) {
-        if ( this.props.words !== prevProps.words ) {
-            this.getData();
-        }
     }
 
     sortColumn( event ) {

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -7,7 +7,7 @@ class Table extends React.Component {
         this.state = {
             columnSortStatus: {
                 currentSortedColumnIndex: -1,
-                value: new Array( 17 ).fill( "undefined" )
+                sortStatus: new Array( 17 ).fill( "undefined" )
             }
         };
     }
@@ -75,7 +75,7 @@ class Table extends React.Component {
 
     renderTableHeaders() {
         return (
-            this.state.columnSortStatus.value.map( ( sortStatus, colIndex ) => {
+            this.state.columnSortStatus.sortStatus.map( ( sortStatus, colIndex ) => {
                 if ( colIndex === 1 ) {
                     return (
                         <th key={ colIndex } scope={ "col" } className={ sortStatus }
@@ -107,7 +107,7 @@ class Table extends React.Component {
     onSortChanges( event ) {
         const clickedColumnIndex = event.target.cellIndex;
 
-        let newColumnSortStatusValue = this.state.columnSortStatus.value.slice();
+        let newColumnSortStatusValue = this.state.columnSortStatus.sortStatus.slice();
 
         newColumnSortStatusValue.map( ( sortDirection, colIndex ) => {
             if ( colIndex === clickedColumnIndex ) {
@@ -118,47 +118,49 @@ class Table extends React.Component {
             }
         } )
 
-        const newColumnSortStatus = {
-            currentSortedColumnIndex: clickedColumnIndex,
-            value: newColumnSortStatusValue
-        }
-
         this.setState( {
-            columnSortStatus: newColumnSortStatus
+            columnSortStatus: {
+                currentSortedColumnIndex: clickedColumnIndex,
+                sortStatus: newColumnSortStatusValue
+            }
         } )
     }
 
     sortColumn() {
 
-        // headers in the table are in the format: [ chinese + pinyin, english ... ]
-        // translationData contains array in the format: [ chinese, pinyin, english ... ]
-        const sortedColumnIndex = this.state.columnSortStatus.currentSortedColumnIndex;
-        const dataIndex = sortedColumnIndex + 1;
-
-        const order = this.state.columnSortStatus.value[ sortedColumnIndex ];
-
         let sortedTranslationData = this.props.data.slice();
-        sortedTranslationData.sort( ( row1, row2 ) => {
+        const sortedColumnIndex = this.state.columnSortStatus.currentSortedColumnIndex;
 
-            let word1 = row1[ dataIndex ];
-            let word2 = row2[ dataIndex ];
+        // check if a column needs to be sorted
+        if ( sortedColumnIndex >= 0 ) {
+            // headers in the table are in the format: [ chinese + pinyin, english ... ]
+            // translationData contains array in the format: [ chinese, pinyin, english ... ]
+            const dataIndex = sortedColumnIndex + 1;
 
-            if ( !word1 ) {
-                return 1;
-            } else if ( !word2 ) {
-                return -1;
-            } else {
+            const order = this.state.columnSortStatus.sortStatus[ sortedColumnIndex ];
 
-                const collator = new Intl.Collator();
+            sortedTranslationData.sort( ( row1, row2 ) => {
 
-                if ( order === "ascending" ) {
-                    return collator.compare( word1, word2 );
+                let word1 = row1[ dataIndex ];
+                let word2 = row2[ dataIndex ];
+
+                if ( !word1 ) {
+                    return 1;
+                } else if ( !word2 ) {
+                    return -1;
                 } else {
-                    return collator.compare( word2, word1 );
-                }
-            }
 
-        } );
+                    const collator = new Intl.Collator();
+
+                    if ( order === "ascending" ) {
+                        return collator.compare( word1, word2 );
+                    } else {
+                        return collator.compare( word2, word1 );
+                    }
+                }
+
+            } );
+        }
 
         return sortedTranslationData;
     }


### PR DESCRIPTION
**Issue:**

To allow users to choose between 10 rows/all and which page to look at, a Toggle Buttons component and a Table Pagination component need to pass information to the Table. After getting the data from the backend, Table also needs to pass how many pages are needed to the Pagination components. There are lots of props being passed around, also Table and Pagination are both passing props to each other, which seems a bit messy. 

**Solution:**

Move all API calling methods to the SearchPage component, the resulted data is passed to the Table as a prop. 
This leads to a new issue:

- The Table originally contains data as a state and changes this state when sorting data. However, it cannot modify its props. 

To solve that, the original sort function is split into two functions. Before displaying the data, a sort function is called to sort the data passed to the Table component based on the columnSortStatus state in Table. If user clicks a header, another function is called to change the columnSortStatus, which will trigger a re-rendering.

After change above, ToggleButton and Pagination components will both change the state of SearchPage based on user's action. New information is passed to all components by the SearchPage component. 

**Risk:**
/ 

**Reviewed by:**
Annie, Yujia, Kevin, Dave, Eileen 
