### PR TITLE
[CMLG-015] Implement the basic functionality of the table pagination

### DIFF
--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -69,34 +69,33 @@ class Pagination extends React.Component {
         if ( totalPages <= centreNumberBlocks + 2 ) {
             displayedPages = range(1, totalPages);
         } else {
-            let hasLeftElipsis = (currentPage - pageNeighbours) > pageNeighbours;
-            let hasRightElipsis = (currentPage + pageNeighbours) < (totalPages + 1 - pageNeighbours);
+            let hasLeftElipsis = currentPage - pageNeighbours > pageNeighbours;
+            let hasRightElipsis = currentPage + pageNeighbours < totalPages + 1 - pageNeighbours;
 
             switch ( true ) {
                 // handle: [1] ... [5] [6] (7) [8] [9]
                 case ( hasLeftElipsis && !hasRightElipsis ): {
                     const pages = range( totalPages + 1 - centreNumberBlocks, totalPages );
-                    displayedPages = [1, ELLIPSIS, ...pages];
+                    displayedPages = [ 1, ELLIPSIS, ...pages ];
                     break;
                 }
 
                 // handle: [1] [2] (3) [4] (5) ...[9]
                 case ( !hasLeftElipsis && hasRightElipsis ): {
                     const pages = range( 1, centreNumberBlocks );
-                    displayedPages = [...pages, ELLIPSIS, totalPages];
+                    displayedPages = [ ...pages, ELLIPSIS, totalPages ];
                     break;
                 }
 
                 // handle: [1] ... [3] [4] (5) [6] [7] ...[9]
-                case ( hasLeftElipsis && hasRightElipsis ):
                 default: {
                     const pages = range( currentPage - pageNeighbours, currentPage + pageNeighbours );
-                    displayedPages = [1, ELLIPSIS, ...pages, ELLIPSIS, totalPages];
+                    displayedPages = [ 1, ELLIPSIS, ...pages, ELLIPSIS, totalPages ];
                     break;
                 }
             }
         }
-        return [LEFT_PAGE, ...displayedPages, RIGHT_PAGE];
+        return [ LEFT_PAGE, ...displayedPages, RIGHT_PAGE ];
     }
 
     render() {
@@ -105,7 +104,7 @@ class Pagination extends React.Component {
         return (
             <nav aria-label="Pagination">
                 <ul className="pagination">
-                    {pages.map( ( page, index ) => {
+                    { pages.map( ( page, index ) => {
 
                         if ( page === LEFT_PAGE ) return (
                             <li key={ index } className="page-item">
@@ -133,7 +132,7 @@ class Pagination extends React.Component {
                         );
 
                         return (
-                            <li key={ index } className={`page-item${ this.state.currentPage === page ? ' active' : '' }`}>
+                            <li key={ index } className={ `page-item${ this.state.currentPage === page ? ' active' : '' }` }>
                                 <a className="page-link" href="#" onClick={ this.handleClick( page ) }>{ page }</a>
                             </li>
                         );

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -1,0 +1,156 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const LEFT_PAGE = 'LEFT';
+const RIGHT_PAGE = 'RIGHT';
+const ELLIPSIS = 'ELIPSIS';
+
+/**
+ * Helper method for creating a range of numbers
+ * range(1, 5) => [1, 2, 3, 4, 5]
+ */
+const range = ( from, to, step = 1 ) => {
+    let i = from;
+    const range = [];
+
+    while ( i <= to ) {
+        range.push( i );
+        i += step;
+    }
+
+    return range;
+}
+
+class Pagination extends React.Component {
+
+    constructor( props ) {
+        super( props )
+        this.state = {
+            currentPage: 1
+        }
+    }
+
+    componentDidMount() {
+        this.goToPage( 1 );
+    }
+
+    goToPage = page => {
+        const { onPageChanged = f => f } = this.props;
+        const currentPage = Math.max( 1, Math.min( page, this.props.totalPages ) );
+
+        this.setState( { currentPage }, () => onPageChanged( currentPage ) );
+    }
+
+    handleClick = page => evt => {
+        evt.preventDefault();
+        this.goToPage( page );
+    }
+
+    handleMoveLeft = evt => {
+        evt.preventDefault();
+        this.goToPage( this.state.currentPage - 1 );
+    }
+
+    handleMoveRight = evt => {
+        evt.preventDefault();
+        this.goToPage( this.state.currentPage + 1 );
+    }
+
+
+    getPageNumbers = () => {
+        const totalPages = this.props.totalPages;
+        const currentPage = this.state.currentPage;
+        const pageNeighbours = this.props.pageNeighbours;
+
+        const centreNumberBlocks = 1 + pageNeighbours * 2;
+        let displayedPages;
+
+        // If number of pages is less than centre block plus elipsis and end number
+        if ( totalPages <= centreNumberBlocks + 2 ) {
+            displayedPages = range(1, totalPages);
+        } else {
+            let hasLeftElipsis = (currentPage - pageNeighbours) > pageNeighbours;
+            let hasRightElipsis = (currentPage + pageNeighbours) < (totalPages + 1 - pageNeighbours);
+
+            switch ( true ) {
+                // handle: [1] ... [5] [6] (7) [8] [9]
+                case ( hasLeftElipsis && !hasRightElipsis ): {
+                    const pages = range( totalPages + 1 - centreNumberBlocks, totalPages );
+                    displayedPages = [1, ELLIPSIS, ...pages];
+                    break;
+                }
+
+                // handle: [1] [2] (3) [4] (5) ...[9]
+                case ( !hasLeftElipsis && hasRightElipsis ): {
+                    const pages = range( 1, centreNumberBlocks );
+                    displayedPages = [...pages, ELLIPSIS, totalPages];
+                    break;
+                }
+
+                // handle: [1] ... [3] [4] (5) [6] [7] ...[9]
+                case ( hasLeftElipsis && hasRightElipsis ):
+                default: {
+                    const pages = range( currentPage - pageNeighbours, currentPage + pageNeighbours );
+                    displayedPages = [1, ELLIPSIS, ...pages, ELLIPSIS, totalPages];
+                    break;
+                }
+            }
+        }
+        return [LEFT_PAGE, ...displayedPages, RIGHT_PAGE];
+    }
+
+    render() {
+        const pages = this.getPageNumbers();
+
+        return (
+            <nav aria-label="Pagination">
+                <ul className="pagination">
+                    {pages.map( ( page, index ) => {
+
+                        if ( page === LEFT_PAGE ) return (
+                            <li key={ index } className="page-item">
+                                <a className="page-link" href="#" aria-label="Previous" onClick={ this.handleMoveLeft }>
+                                    <span aria-hidden="true">&lt;</span>
+                                    <span className="sr-only">Previous</span>
+                                </a>
+                            </li>
+                        );
+
+                        if ( page === RIGHT_PAGE ) return (
+                            <li key={ index } className="page-item">
+                                <a className="page-link" href="#" aria-label="Next" onClick={ this.handleMoveRight }>
+                                    <span aria-hidden="true">&gt;</span>
+                                    <span className="sr-only">Next</span>
+                                </a>
+                            </li>
+                        );
+
+                        if ( page === ELLIPSIS ) return (
+                            <li key={ index } className="page-item">
+                                <span aria-hidden="true">&hellip;</span>
+                                <span className="sr-only"></span>
+                            </li>
+                        );
+
+                        return (
+                            <li key={ index } className={`page-item${ this.state.currentPage === page ? ' active' : '' }`}>
+                                <a className="page-link" href="#" onClick={ this.handleClick( page ) }>{ page }</a>
+                            </li>
+                        );
+
+                    })}
+
+                </ul>
+            </nav>
+        )
+    }
+
+}
+
+Pagination.propTypes = {
+    totalPages: PropTypes.number.isRequired,
+    pageNeighbours: PropTypes.number,
+    onPageChanged: PropTypes.func
+};
+
+export default Pagination 

--- a/src/components/SearchPage.js
+++ b/src/components/SearchPage.js
@@ -22,7 +22,7 @@ class SearchPage extends React.Component {
         };
 
         // only emit changes if this function has not been called in the past 180 ms
-        this.emitChangeDebounced = debounce(this.emitChange, 180);
+        this.emitChangeDebounced = debounce( this.emitChange, 180 );
     }
 
     componentDidMount() {
@@ -85,18 +85,18 @@ class SearchPage extends React.Component {
     retrieveTableData() {
 
         let sequenceTime = new Date();
-        let url = 'https://cmlgbackend.wdcc.co.nz/api/translations?sequence=' + sequenceTime.getTime() +
-                  '&word=' + this.state.word + '&pageNum=' + this.state.currentPage;
+        let url = 'https://cmlgbackend.wdcc.co.nz/api/translations?sequence=' + sequenceTime.getTime() + '&pageNum=' + this.state.currentPage +
+                  '&word=' + this.state.word;
  
-        fetch(url)
-            .then(results => {
+        fetch( url )
+            .then( results => {
                 return results.json();
             })
-            .then(responseData => {
+            .then( responseData => {
                 const data = responseData.data;
                 const sequence = responseData.sequence;
 
-                if (sequence <= this.state.sequenceNumber) {
+                if ( sequence <= this.state.sequenceNumber ) {
                     return;
                 }
 


### PR DESCRIPTION
Issue:
When user only wants to view only 10 results per page, needs a method to view the next 10 results.

Solution:
Add Pagination which allows user to get more results.
Pagination not visible if only a single page of results
(To test change the url fetch to the dev backend)

Risk/Note: CSS and caching to be implemented still.

Reviewed by Emily, Kevin, Eileen, Yujia, Dave