### PR TITLE
[CMLG-019] Add auto focus to the search bar when we load the search page

### DIFF
--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -35,7 +35,7 @@ class SearchBar extends React.Component{
     render() {
         return(
             <div className='search'> 
-                <input className='bar' type="text" placeholder={ this.state.placeholderText } 
+                <input autoFocus className='bar' type="text" placeholder={ this.state.placeholderText }
                        onChange = { ( e ) => this.props.data.changeWord( e.target.value ) }/>
                 <SearchIcon className='search-icon'/>
             </div>


### PR DESCRIPTION
Issue:
Users need to click on the search bar in order to start searching now, but we want the user to search straightforward when they load the page.

Solution: 
Add autoFocus to the search bar.

Risk:
Unknown

Reviewed by:
Kevin, Emily, Yujia, Annie, Dave