### PR TITLE
[CMLG-015] Display 10 rows using frontend

### DIFF
--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -23,13 +23,6 @@ const range = ( from, to, step = 1 ) => {
 
 class Pagination extends React.Component {
 
-    constructor( props ) {
-        super( props )
-        this.state = {
-            currentPage: 1
-        }
-    }
-
     componentDidMount() {
         this.goToPage( 1 );
     }
@@ -38,7 +31,7 @@ class Pagination extends React.Component {
         const { onPageChanged = f => f } = this.props;
         const currentPage = Math.max( 1, Math.min( page, this.props.totalPages ) );
 
-        this.setState( { currentPage }, () => onPageChanged( currentPage ) );
+        onPageChanged( currentPage );
     }
 
     handleClick = page => evt => {
@@ -48,18 +41,18 @@ class Pagination extends React.Component {
 
     handleMoveLeft = evt => {
         evt.preventDefault();
-        this.goToPage( this.state.currentPage - 1 );
+        this.goToPage( this.props.currentPage - 1 );
     }
 
     handleMoveRight = evt => {
         evt.preventDefault();
-        this.goToPage( this.state.currentPage + 1 );
+        this.goToPage( this.props.currentPage + 1 );
     }
 
 
     getPageNumbers = () => {
         const totalPages = this.props.totalPages;
-        const currentPage = this.state.currentPage;
+        const currentPage = this.props.currentPage;
         const pageNeighbours = this.props.pageNeighbours;
 
         const centreNumberBlocks = 1 + pageNeighbours * 2;
@@ -127,12 +120,12 @@ class Pagination extends React.Component {
                         if ( page === ELLIPSIS ) return (
                             <li key={ index } className="page-item">
                                 <span aria-hidden="true">&hellip;</span>
-                                <span className="sr-only"></span>
+                                <span className="sr-only"/>
                             </li>
                         );
 
                         return (
-                            <li key={ index } className={ `page-item${ this.state.currentPage === page ? ' active' : '' }` }>
+                            <li key={ index } className={ `page-item${ this.props.currentPage === page ? ' active' : '' }` }>
                                 <a className="page-link" href="#" onClick={ this.handleClick( page ) }>{ page }</a>
                             </li>
                         );

--- a/src/components/RowsPerPageToggleButton.js
+++ b/src/components/RowsPerPageToggleButton.js
@@ -4,7 +4,7 @@ import "./css/RowsPerPageToggleButton.css"
 export function RowsPerPageToggleButton( props ) {
 	return (
 		<div className="btn-group btn-group-toggle" data-toggle="buttons">
-			<label className="btn btn-light toggle-button rounded-0">
+			<label className="btn btn-light toggle-button rounded-0 active">
 				<input type="radio" name="options" id="10rows" value={ "10" } defaultChecked
 					   onClick={ event => props.onButtonClicked( event.target.value ) }/> 10 rows
 			</label>

--- a/src/components/SearchPage.js
+++ b/src/components/SearchPage.js
@@ -81,8 +81,7 @@ class SearchPage extends React.Component {
 	}
 
     componentDidUpdate( prevProps, prevState, snapshot ) {
-        if ( this.state.word !== prevState.word || this.state.currentPage !== prevState.currentPage
-             || this.state.rowsPerPage !== prevState.rowsPerPage ) {
+        if ( this.state.word !== prevState.word ) {
             this.retrieveTableData();
         }
     }
@@ -99,16 +98,11 @@ class SearchPage extends React.Component {
 
         // for testing, change cmlgbackend.wdcc to cmlgdevbackend.wdcc
         let url = 'https://cmlgbackend.wdcc.co.nz/api/translations?sequence=' + sequenceTime.getTime() +
-                  '&pageRows=' + this.state.rowsPerPage;
+                  '&pageRows=all';
 
         if ( this.state.word !== '' ) {
             // add search words
             url += '&word=' + this.state.word;
-        }
-
-        if ( this.state.rowsPerPage !== "all" ) {
-            // retrieve information for one page only
-            url += '&pageNum=' + this.state.currentPage;
         }
 
         fetch( url )
@@ -149,11 +143,19 @@ class SearchPage extends React.Component {
                         translationsForOneWord = [];
                     }
                 }
+
+                // calculate how many pages are needed if user doesn't want to see all pages
+                let totalPages = responseData.totalPageNum;
+                if ( this.state.rowsPerPage !== "all" ) {
+                    totalPages = Math.ceil( sortedListOfWords.length / this.state.rowsPerPage );
+                }
+
                 this.setState( {
                     tableData: sortedListOfWords,
                     isTableLoading: false,
                     sequenceNumber: sequence,
-                    totalPages: responseData.totalPageNum    
+                    totalPages: totalPages,
+                    currentPage: 1
                 } );
             } )
 
@@ -170,15 +172,15 @@ class SearchPage extends React.Component {
                     <RowsPerPageToggleButton onButtonClicked = { this.handleRowsPerPageChanges }/>
                 </div>
 
-
                 <div className = "table-div">
                     <Table columns = { this.state.selectedColumns }
                            data = { this.state.tableData }
                            isLoading = { this.state.isTableLoading }
+                           currentPage = { this.state.currentPage }
+                           rowsPerPage = { this.state.rowsPerPage }
                     />
                 </div>
                 <div>
-                    { this.state.totalPages > 1 && <Pagination totalPages = { this.state.totalPages } pageNeighbours={ 2 } onPageChanged={ this.onPageChanged } /> }
                     { this.state.totalPages > 1 &&
                       <Pagination totalPages = { this.state.totalPages }
                                   pageNeighbours={ 2 }

--- a/src/components/SearchPage.js
+++ b/src/components/SearchPage.js
@@ -89,7 +89,7 @@ class SearchPage extends React.Component {
 
     // update table on page change
     onPageChanged = data => {
-        this.setState({currentPage: data});
+        this.setState( { currentPage: data } );
     }
 
     // retrieve data for table
@@ -179,6 +179,12 @@ class SearchPage extends React.Component {
                 </div>
                 <div>
                     { this.state.totalPages > 1 && <Pagination totalPages = { this.state.totalPages } pageNeighbours={ 2 } onPageChanged={ this.onPageChanged } /> }
+                    { this.state.totalPages > 1 &&
+                      <Pagination totalPages = { this.state.totalPages }
+                                  pageNeighbours={ 2 }
+                                  onPageChanged={ this.onPageChanged }
+                                  currentPage = { this.state.currentPage }
+                      /> }
                 </div>
             </div>
         );

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -19,7 +19,7 @@ class Table extends React.Component {
             let sortedData = this.sortColumn();
 
             if ( this.props.rowsPerPage !== "all" ) {
-                sortedData = this.getDataNeedTOBeDisplayedOnOnePage( sortedData );
+                sortedData = this.getDisplayedData( sortedData );
             }
 
             return sortedData.map( ( translation, index ) => {
@@ -169,7 +169,7 @@ class Table extends React.Component {
         return sortedTranslationData;
     }
 
-    getDataNeedTOBeDisplayedOnOnePage( sortedData ) {
+    getDisplayedData(sortedData ) {
 
         let dataDisplayed = [];
 

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -16,7 +16,11 @@ class Table extends React.Component {
 
         if ( this.props.data.length !== 0 ) {
 
-            const sortedData = this.sortColumn();
+            let sortedData = this.sortColumn();
+
+            if ( this.props.rowsPerPage !== "all" ) {
+                sortedData = this.getDataNeedTOBeDisplayedOnOnePage( sortedData );
+            }
 
             return sortedData.map( ( translation, index ) => {
 
@@ -163,6 +167,24 @@ class Table extends React.Component {
         }
 
         return sortedTranslationData;
+    }
+
+    getDataNeedTOBeDisplayedOnOnePage( sortedData ) {
+
+        let dataDisplayed = [];
+
+        // only display the required rows of data
+        const startRowIndex = ( this.props.currentPage - 1 ) * this.props.rowsPerPage;
+
+        for ( let rowCount = 0; rowCount < this.props.rowsPerPage; rowCount++ ) {
+            if ( startRowIndex + rowCount < sortedData.length ) {
+                dataDisplayed[ rowCount ] = sortedData[ startRowIndex + rowCount ];
+            } else {
+                break;
+            }
+        }
+
+        return dataDisplayed;
     }
 
     render() {


### PR DESCRIPTION
Issue:
When backend only returns 10 rows of data, the frontend cannot handle sorting itself.
Passing sorting request back to backend may result in too many API requests.

Solution:
Frontend always asks for all the data from the backend, i.e. set rows per page to be "all" for each request. If the user wants to see only 10 rows per page, frontend will calculate the index of the data needs to be displayed and only display the required ones.

Risk:
The backend has functionalities that frontend currently don't need.
Getting all the data means it will take longer for the website to respond when data gets larger.

Reviewed by:
Dave, Annie, Eileen, Kevin, Yujia