### PR TITLE
[CMLG-013] Fix SelectCol Responsive Bugs

### DIFF
--- a/src/components/css/SelectCol.css
+++ b/src/components/css/SelectCol.css
@@ -13,11 +13,24 @@
     padding-left: 10px;
     padding-bottom:10px;
     position: fixed;
-    top: 15%;
+    top: 90px;
     right: 16px;
-    /*overflow:"auto"*/
 }
 
 #language-options {
     z-index: 1000;
+}
+
+@media (max-height: 35rem) {
+   .card {
+       height: 15rem;
+       overflow: auto;
+   }
+}
+
+@media (max-height: 15rem) {
+    .card {
+        height: 7rem;
+        overflow: auto;
+    }
 }

--- a/src/components/css/SelectCol.css
+++ b/src/components/css/SelectCol.css
@@ -13,8 +13,8 @@
     padding-left: 10px;
     padding-bottom:10px;
     position: fixed;
-    top: 90px;
     right: 16px;
+    top: 120px;
 }
 
 #language-options {
@@ -26,6 +26,12 @@
        height: 15rem;
        overflow: auto;
    }
+}
+
+@media (max-width: 760px) {
+    .card {
+        top: 90px;
+    }
 }
 
 @media (max-height: 15rem) {


### PR DESCRIPTION
Issue:
1. The users can't see all the options when the window's height is smaller than the card's size.
2. Try to solve the issue when the window height decrease, the card will move up and cover the selectCol button.

Solution:
1. Resize the card make it smaller than the window size and enable the scrollable.
2. Change the top be fixed px rather than the percentage.

Risk:  
No risk currently.

Reviewed By: 
Emily, Eileen, Annie, Kevin, Dave