### PR TITLE
[CMLG-015] Add css to the toggle button group

### DIFF
--- a/src/components/SearchPage.js
+++ b/src/components/SearchPage.js
@@ -166,10 +166,13 @@ class SearchPage extends React.Component {
             <div className = "search-page">
                 <div>
                     <SearchBar data = { { changeWord: this.handleChangeWord.bind( this ) } }> </SearchBar>
-                    <SelectCol getsSelectedLanguage = { this.handleSelectCol }
-                               allLanguages = { this.state.selectedColumns }/>
 
-                    <RowsPerPageToggleButton onButtonClicked = { this.handleRowsPerPageChanges }/>
+
+                    <div style={ { display: "flow-root" } }>
+                        <SelectCol getsSelectedLanguage = { this.handleSelectCol }
+                                   allLanguages = { this.state.selectedColumns }/>
+                        <RowsPerPageToggleButton onButtonClicked = { this.handleRowsPerPageChanges }/>
+                    </div>
                 </div>
 
                 <div className = "table-div">


### PR DESCRIPTION
Issue:
When the window size is small, the toggle button group component is pushed to the next line. It's not lined up with the select language component.

Soluiton:
Add another div around both select language component and toggle button group, add css "display: flow-root".

Risk:
/

Reviewed by:
Eileen, Dave, Kevin, Yujia, Annie