### PR TITLE
[CMLG-015] fix bugs in render table pagination

### DIFF
--- a/src/components/SearchPage.js
+++ b/src/components/SearchPage.js
@@ -75,8 +75,15 @@ class SearchPage extends React.Component {
     }
 
     handleRowsPerPageChanges( numberOfPagesPerRow ) {
-    	this.setState( {
-			rowsPerPage: numberOfPagesPerRow
+        let totalPages = 1;
+        if ( numberOfPagesPerRow !== "all" ) {
+            // calculate the total pages needed
+            //@Todo only get displayed data from backend
+            totalPages = Math.ceil( this.state.tableData.length / numberOfPagesPerRow );
+        }
+        this.setState( {
+			rowsPerPage: numberOfPagesPerRow,
+            totalPages: totalPages
 		} )
 	}
 
@@ -146,6 +153,7 @@ class SearchPage extends React.Component {
                 }
 
                 // calculate how many pages are needed if user doesn't want to see all pages
+                //@Todo use the value provided by the backend directly
                 let totalPages = responseData.totalPageNum;
                 if ( this.state.rowsPerPage !== "all" ) {
                     totalPages = Math.ceil( sortedListOfWords.length / this.state.rowsPerPage );

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -131,6 +131,7 @@ class Table extends React.Component {
         } )
     }
 
+    //@Todo sorting should be moved to backend
     sortColumn() {
 
         let sortedTranslationData = this.props.data.slice();
@@ -170,6 +171,7 @@ class Table extends React.Component {
         return sortedTranslationData;
     }
 
+    //@Todo this should be moved to backend
     getDisplayedData(sortedData ) {
 
         let dataDisplayed = [];


### PR DESCRIPTION
Issue:
When the user switches between "all" and "10 rows", the totalPages state is not updated.

Solution:
Calculate the new totalPages every time the user switches between "all" and "10 rows".
Adding some todos comments for future changes.

Risk:
/

Reviewed by:
Annie, Eileen, Dave, Yujia, Kevin