### PR TITLE
[CMLG-026]Solve the toggle button dark mode bug by having a state

### DIFF
--- a/src/components/RowsPerPageToggleButton.js
+++ b/src/components/RowsPerPageToggleButton.js
@@ -1,20 +1,22 @@
-import React from 'react';
+import React, { useState } from 'react';
 import "../css/RowsPerPageToggleButton.css"
 
 
 export function RowsPerPageToggleButton( props ) {
 
+	const [row10active, setRow10Active] = useState(true)
+
 	return (
 
 		<div className="btn-group btn-group-toggle" data-toggle="buttons">
-			<label className= { `btn btn-light toggle-button rounded-0 active ${ props.darkMode ? "dark-mode-active" : "" } `}>
+			<label className= { `btn btn-light toggle-button rounded-0 ${ props.darkMode ? "dark-mode" : "" } ${ row10active ? "active" : "" } `}>
 				<input type="radio" name= "options " id="TenRows" value={ "10" } defaultChecked
-					   onClick={ event => props.onButtonClicked( event.target.value ) }/> 10 rows
+					   onClick={ event => { props.onButtonClicked( event.target.value ); setRow10Active(true) }  }/> 10 rows
 			</label>
-			<label className= { `btn btn-light toggle-button rounded-0 ${ props.darkMode ? "dark-mode" : "" } `}>
+			<label className= { `btn btn-light toggle-button rounded-0 ${ props.darkMode ? "dark-mode" : "" } ${ row10active ? "" : "active" } `}>
 
 				<input type="radio" name="options" id="all" value={ "all" }
-					   onClick={ event => props.onButtonClicked( event.target.value ) }/> all
+					   onClick={ event => { props.onButtonClicked( event.target.value ); setRow10Active(false) } }/> all
 			</label>
 		</div>
 	);

--- a/src/components/RowsPerPageToggleButton.js
+++ b/src/components/RowsPerPageToggleButton.js
@@ -4,19 +4,17 @@ import "../css/RowsPerPageToggleButton.css"
 
 export function RowsPerPageToggleButton( props ) {
 
-	const [row10active, setRow10Active] = useState(true)
-
 	return (
 
 		<div className="btn-group btn-group-toggle" data-toggle="buttons">
-			<label className= { `btn btn-light toggle-button rounded-0 ${ props.darkMode ? "dark-mode" : "" } ${ row10active ? "active" : "" } `}>
+			<label className= { `btn btn-light toggle-button rounded-0 ${ props.darkMode ? "dark-mode" : "" } ${ props.activebtn !== "all" ? "active" : "" } `}>
 				<input type="radio" name= "options " id="TenRows" value={ "10" } defaultChecked
-					   onClick={ event => { props.onButtonClicked( event.target.value ); setRow10Active(true) }  }/> 10 rows
+					   onClick={ event => { props.onButtonClicked( event.target.value ) }  }/> 10 rows
 			</label>
-			<label className= { `btn btn-light toggle-button rounded-0 ${ props.darkMode ? "dark-mode" : "" } ${ row10active ? "" : "active" } `}>
+			<label className= { `btn btn-light toggle-button rounded-0 ${ props.darkMode ? "dark-mode" : "" } ${ props.activebtn === "all" ? "active" : "" } `}>
 
 				<input type="radio" name="options" id="all" value={ "all" }
-					   onClick={ event => { props.onButtonClicked( event.target.value ); setRow10Active(false) } }/> all
+					   onClick={ event => { props.onButtonClicked( event.target.value ) } }/> all
 			</label>
 		</div>
 	);

--- a/src/components/RowsPerPageToggleButton.js
+++ b/src/components/RowsPerPageToggleButton.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import "../css/RowsPerPageToggleButton.css"
 
 
@@ -7,11 +7,11 @@ export function RowsPerPageToggleButton( props ) {
 	return (
 
 		<div className="btn-group btn-group-toggle" data-toggle="buttons">
-			<label className= { `btn btn-light toggle-button rounded-0 ${ props.darkMode ? "dark-mode" : "" } ${ props.activebtn !== "all" ? "active" : "" } `}>
+			<label className= { `btn btn-light toggle-button rounded-0 ${ props.darkMode ? "dark-mode" : "" } ${ props.activeButton !== "all" ? "active" : "" } `}>
 				<input type="radio" name= "options " id="TenRows" value={ "10" } defaultChecked
 					   onClick={ event => { props.onButtonClicked( event.target.value ) }  }/> 10 rows
 			</label>
-			<label className= { `btn btn-light toggle-button rounded-0 ${ props.darkMode ? "dark-mode" : "" } ${ props.activebtn === "all" ? "active" : "" } `}>
+			<label className= { `btn btn-light toggle-button rounded-0 ${ props.darkMode ? "dark-mode" : "" } ${ props.activeButton === "all" ? "active" : "" } `}>
 
 				<input type="radio" name="options" id="all" value={ "all" }
 					   onClick={ event => { props.onButtonClicked( event.target.value ) } }/> all

--- a/src/components/SearchPage.js
+++ b/src/components/SearchPage.js
@@ -181,7 +181,7 @@ class SearchPage extends React.Component {
                                    getsSelectedLanguage = { this.handleSelectCol }
                                    allLanguages = { this.state.selectedColumns }/>
 
-                        <RowsPerPageToggleButton darkMode= {this.props.darkMode} onButtonClicked = { this.handleRowsPerPageChanges }/>
+                        <RowsPerPageToggleButton darkMode= {this.props.darkMode} onButtonClicked = { this.handleRowsPerPageChanges } activebtn = { this.state.rowsPerPage }/>
                     </div>
 
                 </div>

--- a/src/components/SearchPage.js
+++ b/src/components/SearchPage.js
@@ -181,7 +181,7 @@ class SearchPage extends React.Component {
                                    getsSelectedLanguage = { this.handleSelectCol }
                                    allLanguages = { this.state.selectedColumns }/>
 
-                        <RowsPerPageToggleButton darkMode= {this.props.darkMode} onButtonClicked = { this.handleRowsPerPageChanges } activebtn = { this.state.rowsPerPage }/>
+                        <RowsPerPageToggleButton darkMode= {this.props.darkMode} onButtonClicked = { this.handleRowsPerPageChanges } activeButton = { this.state.rowsPerPage }/>
                     </div>
 
                 </div>

--- a/src/css/RowsPerPageToggleButton.css
+++ b/src/css/RowsPerPageToggleButton.css
@@ -11,8 +11,4 @@
     color: white ;
 }
 
-.dark-mode-active {
-    color: white ;
-    background-color: black;
-}
 


### PR DESCRIPTION
Issue:
There is a bug about the active button. If you turn on on the dark mode after you click the "all" button, in dark mode, the "10 rows" button is highlighted instead of the "all" button. The details is stated in Github Issues #67

Solution:
Having an active state for the toggle button group.

Risk:
Unknown

Reviewed by:
Annie, Eileen, Dave, Yujia, Emily