### PR TITLE
[CMLG-027] Fix select col type error

### DIFF
--- a/src/components/HeaderBar.js
+++ b/src/components/HeaderBar.js
@@ -36,7 +36,7 @@ class HeaderBar extends React.Component {
     }
 
     handleClickOutside( event ) {
-        if (!this.node.contains( event.target ) ) {
+        if ( this.node && !this.node.contains( event.target ) ) {
             this.setState( {
                 BarOpen: window.innerWidth > 600
             } );

--- a/src/components/SelectCol.js
+++ b/src/components/SelectCol.js
@@ -34,7 +34,7 @@ class SelectCol extends React.Component {
     }
 
     handleClickOutside = event => {
-        if (!this.node.contains( event.target ) ) {
+        if ( this.node && !this.node.contains( event.target ) ) {
             this.onButtonClick();
         }
     }


### PR DESCRIPTION
Issue:
When we're open the select col component and click on other page, it will produce a null type error.

Solution:
Check if the ref node exist.

Risk:
Change in selectcol component.

Reviewed by:
Emily, Yujia, Kevin, Annie, Dave