### PR TITLE
[CMLG-035] Start searching button in dark mode

### DIFF
--- a/src/components/HelloWorld.js
+++ b/src/components/HelloWorld.js
@@ -1,0 +1,1 @@
+console.log("Hello World");

--- a/src/components/WelcomePage.js
+++ b/src/components/WelcomePage.js
@@ -6,7 +6,7 @@ class WelcomePage extends React.Component {
     render() {
         return (
             <div className={ ` welcomePage ${ this.props.darkMode ? "dark-mode" : "" } ` }>
-                <h1 id="title-txt">COVID-19 Multilingual Glossary</h1>
+                <h1 id="title-txt"> hi :) </h1>
                 <br />
                 <Link to="/translations">
                     <button type="button" className={ ` btn btn-outline-dark 

--- a/src/css/WelcomePage.css
+++ b/src/css/WelcomePage.css
@@ -42,10 +42,17 @@ body {
 
 
 .btn-dark-mode{
-    background-color: black;
-    color: white;
+    background-color: rgb(0, 0, 0);
+    color: rgb(255, 255, 255);
     border-width: 2px;
-    border-color: white;
+    border-color: rgb(255, 255, 255);
+}
+
+.btn-dark-mode:hover{
+    background-color: rgb(255, 255, 255);
+    color: rgb(0, 0, 0);
+    border-width: 2px;
+    border-color: rgb(0, 0, 0);
 }
 
 


### PR DESCRIPTION
Issue :
On dark mode, when you hover over the button, the colours are not inverted.
We want a white background with black text but we previously had a grey background with white text.

Solution :
Added .btn-dark-mode:hover in WelcomPage.css to invert the colours when you hover over it.

Risk :
Button colour could be incorrect

Reviewed by :
Dave, Annie, Kevin, Eileen, Hayoon, Clarissa